### PR TITLE
Use VNC to connect to Windows instances

### DIFF
--- a/src/guacscanner/ConnectionParameters.py
+++ b/src/guacscanner/ConnectionParameters.py
@@ -16,6 +16,7 @@ class ConnectionParameters:
         "rdp_username",
         "vnc_password",
         "vnc_username",
+        "windows_sftp_base",
     )
 
     """The private SSH key to use when transferring data via VNC."""
@@ -32,3 +33,6 @@ class ConnectionParameters:
 
     """The user name to use when Guacamole establishes a VNC connection."""
     vnc_username: str
+
+    """The base path to use for configuring SFTP connections to Windows instances."""
+    windows_sftp_base: str

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.0.2"
+__version__ = "1.1.0-rc.1"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.0-rc.2"
+__version__ = "1.1.0"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.0-rc.1"
+__version__ = "1.1.0-rc.2"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -471,6 +471,8 @@ def add_instance_connection(
                     "sftp-server-alive-interval",
                     60,
                 ),
+                # This must be the root of the filesystem to give access to any
+                # network drives through Guacamole's file sharing functionality.
                 (
                     connection_id,
                     "sftp-root-directory",

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -362,6 +362,8 @@ def add_instance_connection(
     connection_name = get_connection_name(instance)
     is_windows = False
     connection_protocol = "vnc"
+    # Note that the Windows VNC server software in use must support a connection
+    # to display 1 for this port to work.
     connection_port = 5901
     if instance.platform and instance.platform.lower() == "windows":
         logging.debug(
@@ -369,7 +371,6 @@ def add_instance_connection(
             instance.id,
         )
         is_windows = True
-        connection_port = 5900
 
     with db_connection.cursor() as cursor:
         cursor.execute(

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -87,6 +87,7 @@ def test_log_levels(level):
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={DUMMY_VPC_ID}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(logging.root, "handlers", []):
@@ -157,6 +158,7 @@ def test_addition_of_guacuser():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(
@@ -206,6 +208,7 @@ def test_guacuser_already_exists():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(
@@ -279,6 +282,7 @@ def test_new_linux_instance():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(
@@ -349,6 +353,7 @@ def test_terminated_instance():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(
@@ -414,6 +419,7 @@ def test_stopped_instance():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(
@@ -487,6 +493,7 @@ def test_new_windows_instance():
             "--vnc-password=dummy_vnc_password",
             "--vnc-username=dummy_vnc_username",
             f"--vpc-id={vpc_id}",
+            "--windows-sftp-base=/C:/Users/dummy_user",
         ],
     ):
         with patch.object(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the logic for Windows instances to use VNC instead of RDP. A new parameter to configure the SFTP connection required for file transfers using VNC has been added as well.

I have corresponding PRs in the following repositories to support these changes:

- https://github.com/cisagov/guacscanner-docker/pull/5
- https://github.com/cisagov/guacamole-composition/pull/31
- https://github.com/cisagov/ansible-role-guacamole/pull/40
- https://github.com/cisagov/guacamole-packer/pull/56
- https://github.com/cisagov/cool-assessment-terraform/pull/158

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Due to limitations with RDP with the version of Windows currently in use we need to switch to VNC to meet the needs of Guacamole users. The way the instances are currently built also requires us to provide a base path for the SFTP connection to use.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Automated tests pass. I have tested this configuration in my testing environment with a supporting Windows image and both VNC and file transfers work. This change should resolve https://github.com/cisagov/cool-system-internal/issues/54 and https://github.com/cisagov/cool-system-internal/issues/63.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version
