### PR TITLE
Change SFTP base directory for non-Windows connections

### DIFF
--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.1-rc.1"
+__version__ = "1.1.1"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.1"
+__version__ = "1.1.1-rc.1"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -416,7 +416,7 @@ def add_instance_connection(
             (
                 connection_id,
                 "sftp-root-directory",
-                f"/home/{connection_parameters.vnc_username}/",
+                "/",
             ),
             (
                 connection_id,


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the SFTP base directory for non-Windows connections.

## 💭 Motivation and context ##

This is necessary for the Guacamole file browser to correct interpret the symlink to the EFS file share that resides on the VNC user's desktop in the GoPhish instance type.  The same change was already made by @mcdonnnj for Windows connections.

## 🧪 Testing ##

I created a new [`guacscanner` AMI](https://github.com/guacamole-packer) for our COOL staging environment with these changes and verified that the file share symlink is now interpreted correctly.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.