### PR TITLE
Make the default log level warning

### DIFF
--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.2.9"
+__version__ = "1.2.10"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -15,7 +15,7 @@ Options:
   -h --help              Show this message.
   --log-level=LEVEL      If specified, then the log level will be set to
                          the specified value.  Valid values are "debug", "info",
-                         "warning", "error", and "critical". [default: info]
+                         "warning", "error", and "critical". [default: warning]
   --oneshot              If present then the loop that adds (removes) connections for new (terminated) instances will only be run once.
   --postgres-password=PASSWORD    If specified then the specified value will be used as the password when connecting to the PostgreSQL database.  Otherwise, the password will be read from a local file.
   --postgres-password-file=FILENAME    The file from which the PostgreSQL password will be read. [default: /run/secrets/postgres-password]


### PR DESCRIPTION
## 🗣 Description ##

Make the default log level `warning`.  This will help prevent guacscanner logs from growing too large.

## 💭 Motivation and context ##

~Resolves cisagov/guacamole-composition#54.~

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
