### PR TITLE
Use `psycopg.conninfo.make_conninfo()` to create PostgreSQL connection string

### DIFF
--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.2-rc.3"
+__version__ = "3.0.2-rc.4"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.2-rc.4"
+__version__ = "3.0.2"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.2-rc.2"
+__version__ = "3.0.2-rc.3"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -874,11 +874,11 @@ def main() -> None:
     # ensure that any special characters (such as backslashes) are safely
     # escaped.
     db_connection_string = psycopg.conninfo.make_conninfo(
-        user=postgres_username,
-        password=postgres_password,
-        host=postgres_hostname,
-        port=postgres_port,
         dbname=postgres_db_name,
+        host=postgres_hostname,
+        password=postgres_password,
+        port=postgres_port,
+        user=postgres_username,
     )
 
     vpc_id = validated_args["--vpc-id"]

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -24,8 +24,7 @@ Options:
   -h --help              Show this message.
   --log-level=LEVEL    If specified, then the log level will be set to
     the specified value.  Valid values are "notset", "debug", "info",
-    "warning", "warn", "error", "fatal", and "critical". [default:
-    info]
+    "warning", "warn", "error", "fatal", and "critical". [default: info]
   --oneshot    If present then the loop that adds (removes)
     connections for new (terminated) instances will only be run once.
   --postgres-hostname=HOSTNAME    If specified then the specified
@@ -36,14 +35,12 @@ Options:
     PostgreSQL database.  Otherwise, the password will be read from a
     local file.
   --postgres-password-file=FILENAME    The file from which the
-    PostgreSQL password will be read. [default:
-    /run/secrets/postgres-password]
+    PostgreSQL password will be read. [default: /run/secrets/postgres-password]
   --postgres-username=USERNAME    If specified then the specified
     value will be used when connecting to the PostgreSQL database.
     Otherwise, the username will be read from a local file.
   --postgres-username-file=FILENAME    The file from which the
-    PostgreSQL username will be read. [default:
-    /run/secrets/postgres-username]
+    PostgreSQL username will be read. [default: /run/secrets/postgres-username]
   --private-ssh-key=KEY  If specified then the specified value will be
     used for the private SSH key.  Otherwise, the SSH key will be read
     from a local file.
@@ -80,8 +77,8 @@ Options:
     will be used as the base path for configuring Windows SFTP
     connections.  Otherwise, the path will be read from a local file.
   --windows-sftp-base-file=FILENAME    The file from which the base
-    path for Windows SFTP connections will be read. [default:
-    /run/secrets/windows-sftp-base]
+    path for Windows SFTP connections will be read.
+    [default: /run/secrets/windows-sftp-base]
 """
 
 # Standard Python Libraries

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -870,10 +870,12 @@ def main() -> None:
         with open(validated_args["--windows-sftp-base-file"]) as file:
             windows_sftp_base = file.read().strip()
 
+    # We use a raw string here since the password, in particular, could contain
+    # a literal backslash.
     db_connection_string = (
-        f"user={postgres_username} password={postgres_password} "
-        f"host={postgres_hostname} port={postgres_port} "
-        f"dbname={postgres_db_name}"
+        rf"user={postgres_username} password={postgres_password} "
+        rf"host={postgres_hostname} port={postgres_port} "
+        rf"dbname={postgres_db_name}"
     )
 
     vpc_id = validated_args["--vpc-id"]

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -870,12 +870,15 @@ def main() -> None:
         with open(validated_args["--windows-sftp-base-file"]) as file:
             windows_sftp_base = file.read().strip()
 
-    # We use a raw string here since the password, in particular, could contain
-    # a literal backslash.
-    db_connection_string = (
-        rf"user={postgres_username} password={postgres_password} "
-        rf"host={postgres_hostname} port={postgres_port} "
-        rf"dbname={postgres_db_name}"
+    # Construct the PostgreSQL connection string using psycopg's helper to
+    # ensure that any special characters (such as backslashes) are safely
+    # escaped.
+    db_connection_string = psycopg.conninfo.make_conninfo(
+        user=postgres_username,
+        password=postgres_password,
+        host=postgres_hostname,
+        port=postgres_port,
+        dbname=postgres_db_name,
     )
 
     vpc_id = validated_args["--vpc-id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,9 +230,9 @@ def random_postgres_string(max_chars):
     # Inject a random special ASCII character sequence
     half = math.floor(length / 2)
     s = (
-        s[: half + 1]
+        s[:half]
         + random.choice(SPECIAL_CHAR_SEQUENCES)  # noqa: DUO102 # nosec B311
-        + s[half + 1 :]
+        + s[half:]
     )
 
     return s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,7 @@ def random_postgres_string(max_chars):
     # flake8 and bandit give DUO102 and B311 errors, respectively, for
     # the use of random in this code, but since we're not using it for
     # cryptographic purposes it's OK.
-    length = random.randint(1, max_chars - 2)  # noqa: DUO102 # nosec B311
+    length = random.randint(0, max_chars - 2)  # noqa: DUO102 # nosec B311
     s = "".join(random.choices(source_chars, k=length))  # noqa: DUO102 # nosec B311
     # Inject a random special ASCII character sequence
     half = math.floor(length / 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,9 +215,28 @@ def secrets_dir():
 
 
 def random_postgres_string(max_chars):
-    """Return random string suitable for a PostgreSQL password.
+    r"""Return random string suitable for a PostgreSQL password.
 
     max_chars must be greater than 1.
+
+    When we spun up COOL dev-a and staging-a last year @dav3r
+    generated random passwords for the PostgreSQL password secrets.
+    One of these happened to contain two consecutive characters that
+    could be interpreted as an escape sequence, say a '\' followed
+    by a 't'.  As a PostgreSQL password such characters should be
+    interpreted as \\t and that is what
+    psycopg.conninfo.make_conninfo() does.  See _param_escape()[1],
+    which is called by psycopg.conninfo.make_conninfo.
+
+    The intent of this function is to generate a random string that
+    can be used to test whether a PostgreSQL password containing two
+    bytes that _could_ be interpreted as an escape sequence is
+    handled correctly.
+
+    [1]:
+    https://github.com/psycopg/psycopg/blob/57db5c86b71741a967001e62b784984115741525/psycopg/psycopg/conninfo.py#L106-L120
+    [2]:
+    https://github.com/psycopg/psycopg/blob/57db5c86b71741a967001e62b784984115741525/psycopg/psycopg/conninfo.py#L59
     """
     assert max_chars > 1, "max_chars must be greater than one."
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,18 +214,21 @@ def secrets_dir():
     d.rmdir()
 
 
-def random_postgres_string(max_length):
-    """Return random string suitable for a PostgreSQL username or password."""
+def random_postgres_string(max_chars):
+    """Return random string suitable for a PostgreSQL password.
+
+    max_chars must be greater than 1.
+    """
     source_chars = string.ascii_letters + string.digits + string.punctuation
     # flake8 and bandit give DUO102 and B311 errors, respectively, for
     # the use of random in this code, but since we're not using it for
     # cryptographic purposes it's OK.
-    length = random.randint(1, max_length - 1)  # noqa: DUO102 # nosec B311
+    length = random.randint(1, max_chars - 2)  # noqa: DUO102 # nosec B311
     s = "".join(random.choices(source_chars, k=length))  # noqa: DUO102 # nosec B311
     # Inject a random special ASCII character sequence
     half = math.floor(length / 2)
     s = (
-        s[:half]
+        s[: half + 1]
         + random.choice(SPECIAL_CHAR_SEQUENCES)  # noqa: DUO102 # nosec B311
         + s[half + 1 :]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,9 @@ def postgres_username_secret(secrets_dir):
 
 
 @pytest.fixture
+# We include the PostgreSQL password and username secret fixtures as
+# arguments even though they are never used to ensure that they are
+# created.
 def dockerc(postgres_password_secret, postgres_username_secret):
     """Start up the Docker composition."""
     docker = DockerClient(compose_files=["tests/compose.yml"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,8 @@ def random_postgres_string(max_chars):
 
     max_chars must be greater than 1.
     """
+    assert max_chars > 1, "max_chars must be greater than one."
+
     source_chars = string.ascii_letters + string.digits + string.punctuation
     # flake8 and bandit give DUO102 and B311 errors, respectively, for
     # the use of random in this code, but since we're not using it for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ PASSWORD_MAX_LENGTH = 100
 
 # Some special character sequences that we want to inject into our
 # PostgreSQL password to see if our code handles them.
-SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\", " "]
+SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\\\", "  "]
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,11 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 
 # Standard Python Libraries
 import itertools
+import math
 import os
 from pathlib import Path
 import random
+import string
 import sys
 
 # Third-Party Libraries
@@ -15,6 +17,13 @@ import boto3
 from moto import mock_aws
 import pytest
 from python_on_whales import DockerClient
+
+# Maximum length for PostgreSQL passwords
+PASSWORD_MAX_LENGTH = 100
+
+# Some special char swquences that we want to inject into our PostgreSQL
+# password to see if our code handles them.
+SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\", " "]
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -205,12 +214,34 @@ def secrets_dir():
     d.rmdir()
 
 
+def random_postgres_string(max_length):
+    """Return random string suitable for a PostgreSQL username or password."""
+    source_chars = string.ascii_letters + string.digits + string.punctuation
+    # flake8 and bandit give DUO102 and B311 errors, respectively, for
+    # the use of random in this code, but since we're not using it for
+    # cryptographic purposes it's OK.
+    length = random.randint(1, max_length)  # noqa: DUO102 # nosec B311
+    s = "".join(random.choices(source_chars, k=length))  # noqa: DUO102 # nosec B311
+    # Inject a random special ASCII character sequence
+    half = math.floor(length / 2)
+    s = (
+        s[:half]
+        + random.choice(SPECIAL_CHAR_SEQUENCES)  # noqa: DUO102 # nosec B311
+        + s[half + 1 :]
+    )
+
+    return s
+
+
 @pytest.fixture
 def postgres_password_secret(secrets_dir):
-    """Return a pathlib Path to the postgres password secret."""
+    """Return a pathlib Path to the randomly-generated postgres password secret."""
+    # Delete any existing file
     f = Path(secrets_dir, "postgres-password")
     f.unlink(missing_ok=True)
-    f.write_text("dummy_password")
+
+    # Generate and save a random password
+    f.write_text(random_postgres_string(PASSWORD_MAX_LENGTH))
     yield f
     f.unlink()
 
@@ -218,8 +249,11 @@ def postgres_password_secret(secrets_dir):
 @pytest.fixture(scope="session")
 def postgres_username_secret(secrets_dir):
     """Return a pathlib Path to the postgres user name secret."""
+    # Delete any existing file
     f = Path(secrets_dir, "postgres-username")
     f.unlink(missing_ok=True)
+
+    # Save the user name
     f.write_text("dummy_user")
     yield f
     f.unlink()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ from python_on_whales import DockerClient
 # Maximum length for PostgreSQL passwords
 PASSWORD_MAX_LENGTH = 100
 
-# Some special char swquences that we want to inject into our PostgreSQL
-# password to see if our code handles them.
+# Some special character sequences that we want to inject into our
+# PostgreSQL password to see if our code handles them.
 SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\", " "]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ PASSWORD_MAX_LENGTH = 100
 
 # Some special character sequences that we want to inject into our
 # PostgreSQL password to see if our code handles them.
-SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\\\", "  "]
+SPECIAL_CHAR_SEQUENCES = ["\\n", "\\r", "\\t", "\\\\"]
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,7 @@ def random_postgres_string(max_length):
     # flake8 and bandit give DUO102 and B311 errors, respectively, for
     # the use of random in this code, but since we're not using it for
     # cryptographic purposes it's OK.
-    length = random.randint(1, max_length)  # noqa: DUO102 # nosec B311
+    length = random.randint(1, max_length - 1)  # noqa: DUO102 # nosec B311
     s = "".join(random.choices(source_chars, k=length))  # noqa: DUO102 # nosec B311
     # Inject a random special ASCII character sequence
     half = math.floor(length / 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 # Standard Python Libraries
 import itertools
 import os
+from pathlib import Path
 import random
 import sys
 
@@ -194,8 +195,38 @@ def args(monkeypatch, vpc_id):
     return _args
 
 
+@pytest.fixture(scope="session")
+def secrets_dir():
+    """Path representing the location of the secrets for the Docker composition."""
+    tests_dir = Path(__file__).parent
+    d = Path(tests_dir, "secrets")
+    d.mkdir()
+    yield d
+    d.rmdir()
+
+
 @pytest.fixture
-def dockerc():
+def postgres_password_secret(secrets_dir):
+    """Return a pathlib Path to the postgres password secret."""
+    f = Path(secrets_dir, "postgres-password")
+    f.unlink(missing_ok=True)
+    f.write_text("dummy_password")
+    yield f
+    f.unlink()
+
+
+@pytest.fixture(scope="session")
+def postgres_username_secret(secrets_dir):
+    """Return a pathlib Path to the postgres user name secret."""
+    f = Path(secrets_dir, "postgres-username")
+    f.unlink(missing_ok=True)
+    f.write_text("dummy_user")
+    yield f
+    f.unlink()
+
+
+@pytest.fixture
+def dockerc(postgres_password_secret, postgres_username_secret):
     """Start up the Docker composition."""
     docker = DockerClient(compose_files=["tests/compose.yml"])
     docker.compose.up(detach=True, start=False, wait=True, wait_timeout=60)
@@ -221,10 +252,7 @@ def postgres_db_name():
     return "guacamole_db"
 
 
-@pytest.fixture(scope="session")
-def postgres_username():
+@pytest.fixture
+def postgres_username(postgres_username_secret):
     """Return the username to use when connecting to the postgres instance."""
-    with open("tests/secrets/postgres-username") as file:
-        postgres_username = file.read().strip()
-
-    return postgres_username
+    return postgres_username_secret.read_text().strip()

--- a/tests/secrets/postgres-password
+++ b/tests/secrets/postgres-password
@@ -1,1 +1,0 @@
-dummy_password

--- a/tests/secrets/postgres-username
+++ b/tests/secrets/postgres-username
@@ -1,1 +1,0 @@
-dummy_user

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -92,6 +92,30 @@ class TestLogLevels:
             level
         ), f"root logger level should be set to {level.upper()} or equivalent"
 
+    @pytest.mark.usefixtures("postgres_container")
+    def test_no_log_level_specified(self, args, monkeypatch):
+        """Verify that case where no log level is specified."""
+        args("DEBUG")
+        # Drop the --log-level argument
+        monkeypatch.setattr(sys, "argv", sys.argv[:1] + sys.argv[2:])
+
+        monkeypatch.setattr(logging.root, "handlers", [])
+        assert (
+            logging.root.hasHandlers() is False
+        ), "root logger should not have handlers yet"
+
+        guacscanner.guacscanner.main()
+
+        assert (
+            logging.root.hasHandlers() is True
+        ), "root logger should now have a handler"
+        # Here we check the numerical levels since, e.g., WARN and
+        # WARNING are equivalent levels with different names, as are
+        # FATAL and CRITICAL.
+        assert logging.root.getEffectiveLevel() == logging.getLevelName(
+            "INFO"
+        ), "root logger level should be set to INFO or equivalent"
+
     def test_bad_log_level(self, monkeypatch):
         """Validate bad log-level argument returns error."""
         monkeypatch.setattr(sys, "argv", ["bogus", "--log-level=emergency"])


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Python code to use [`psycopg.conninfo.make_conninfo()`](https://www.psycopg.org/psycopg3/docs/api/conninfo.html#psycopg.conninfo.make_conninfo) to create the PostgreSQL connection string.

See also:
- cisagov/guacscanner-docker#44
- cisagov/guacamole-composition#81
- cisagov/ansible-role-guacamole#91
- cisagov/guacamole-packer#127

## 💭 Motivation and context ##

If the PostgreSQL password, for example, contains a literal backslash (`\`) character then we do not want it to be interpreted as the first character in a Python string escape sequence.  

It is highly unlikely that anyone would choose a host name, database name, username, or password that genuinely contains special characters like `\n`, `\t`, etc.; therefore, it should be safe to treat all backslashes in the PostgreSQL connection string as literal backslashes.

## 🧪 Testing ##

All automated tests pass.  I also deployed a new [cisagov/guacamole-packer](https://github.com/cisagov/guacamole-packer) AMI with this change as part of the testing for cisagov/guacamole-packer#127 and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump version.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
