### PR TITLE
Update connection names as instance IPs change

### DIFF
--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1-rc.5"
+__version__ = "3.0.1"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1-rc.1"
+__version__ = "3.0.1-rc.2"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1-rc.4"
+__version__ = "3.0.1-rc.5"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1-rc.3"
+__version__ = "3.0.1-rc.4"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.1-rc.2"
+__version__ = "3.0.1-rc.3"

--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.0"
+__version__ = "3.0.1-rc.1"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -572,10 +572,28 @@ def add_instance_connection(
     db_connection.commit()
 
 
+def update_connection_name(db_connection, connection_id, connection_name):
+    """Update the name associated with a connection."""
+    with db_connection.cursor() as cursor:
+        logging.debug(
+            "Updating connection name for connection_id %s to %s.",
+            connection_id,
+            connection_name,
+        )
+        cursor.execute(
+            UPDATE_CONNECTION_NAME_QUERY,
+            (connection_name, connection_id),
+        )
+
+    # Commit all pending transactions to the database
+    db_connection.commit()
+
+
 def update_instance_connections(db_connection, instance):
     """Update the name of all connections corresponding to the EC2 instance."""
     instance_id = instance.id
     connection_name = get_connection_name(instance)
+    logging.debug("Updating connection names for %s.", instance_id)
     with db_connection.cursor() as cursor:
         cursor.execute(
             IDS_QUERY,
@@ -585,12 +603,8 @@ def update_instance_connections(db_connection, instance):
             ),
         )
         for record in cursor:
-            logging.debug("Updating connection names for %s.", instance_id)
             connection_id = record["connection_id"]
-            cursor.execute(
-                UPDATE_CONNECTION_NAME_QUERY,
-                (connection_name, connection_id),
-            )
+            update_connection_name(db_connection, connection_id, connection_name)
 
     # Commit all pending transactions to the database
     db_connection.commit()

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -140,7 +140,8 @@ INSERT_CONNECTION_QUERY = psycopg.sql.SQL(
 UPDATE_CONNECTION_NAME_QUERY = psycopg.sql.SQL(
     """UPDATE {table}
     SET {name_field} = %s
-    WHERE {id_field} = %s;"""
+    WHERE {id_field} = %s
+    AND {name_field} IS DISTINCT FROM %s;"""
 ).format(
     table=psycopg.sql.Identifier("guacamole_connection"),
     name_field=psycopg.sql.Identifier("connection_name"),
@@ -582,7 +583,7 @@ def update_connection_name(db_connection, connection_id, connection_name):
         )
         cursor.execute(
             UPDATE_CONNECTION_NAME_QUERY,
-            (connection_name, connection_id),
+            (connection_name, connection_id, connection_name),
         )
 
     # Commit all pending transactions to the database

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -603,7 +603,7 @@ def update_instance_connections(db_connection, instance):
                 instance_id,
             ),
         )
-        for record in cursor:
+        for record in cursor.fetchall():
             connection_id = record["connection_id"]
             update_connection_name(db_connection, connection_id, connection_name)
 

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -674,9 +674,15 @@ def process_instance(
                 entity_id,
             )
         else:
+            # The instance already exists in the database, so we will
+            # just update the connection name in case IPs have changed.
             logging.debug(
                 "Connection for %s already exists in the database.", instance_id
             )
+            logging.info(
+                "Updating connection name for %s in case IPs have changed.", instance_id
+            )
+            update_instance_connections(db_connection, instance)
     elif state in remove_instance_states:
         logging.info(
             "Instance %s is in state %s and will be removed if present.",

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -140,7 +140,7 @@ INSERT_CONNECTION_QUERY = psycopg.sql.SQL(
 UPDATE_CONNECTION_NAME_QUERY = psycopg.sql.SQL(
     """UPDATE {table}
     SET {name_field} = '%s'
-    WHERE {id_field} = '%s';"""
+    WHERE {id_field} = %s;"""
 ).format(
     table=psycopg.sql.Identifier("guacamole_connection"),
     name_field=psycopg.sql.Identifier("connection_name"),

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -139,7 +139,7 @@ INSERT_CONNECTION_QUERY = psycopg.sql.SQL(
 )
 UPDATE_CONNECTION_NAME_QUERY = psycopg.sql.SQL(
     """UPDATE {table}
-    SET {name_field} = '%s'
+    SET {name_field} = %s
     WHERE {id_field} = %s;"""
 ).format(
     table=psycopg.sql.Identifier("guacamole_connection"),

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -94,7 +94,8 @@ VPC_ID_REGEX = re.compile(r"^vpc-([0-9a-f]{8}|[0-9a-f]{17})$")
 # separately so that they can be reused where that is possible.  See
 # cisagov/guacscanner#3 for more details.
 
-# The PostgreSQL queries used for adding and removing connections
+# The PostgreSQL queries used for adding, removing, and updating
+# connections
 COUNT_QUERY = psycopg.sql.SQL(
     "SELECT COUNT({id_field}) FROM {table} WHERE {name_field} = %s AND {value_field} = %s"
 ).format(
@@ -134,6 +135,15 @@ INSERT_CONNECTION_QUERY = psycopg.sql.SQL(
     proxy_port_field=psycopg.sql.Identifier("proxy_port"),
     proxy_hostname_field=psycopg.sql.Identifier("proxy_hostname"),
     proxy_encryption_method_field=psycopg.sql.Identifier("proxy_encryption_method"),
+    id_field=psycopg.sql.Identifier("connection_id"),
+)
+UPDATE_CONNECTION_NAME_QUERY = psycopg.sql.SQL(
+    """UPDATE {table}
+    SET {name_field} = '%s'
+    WHERE {id_field} = '%s';"""
+).format(
+    table=psycopg.sql.Identifier("guacamole_connection"),
+    name_field=psycopg.sql.Identifier("connection_name"),
     id_field=psycopg.sql.Identifier("connection_id"),
 )
 INSERT_CONNECTION_PARAMETER_QUERY = psycopg.sql.SQL(

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -572,6 +572,30 @@ def add_instance_connection(
     db_connection.commit()
 
 
+def update_instance_connections(db_connection, instance):
+    """Update the name of all connections corresponding to the EC2 instance."""
+    instance_id = instance.id
+    connection_name = get_connection_name(instance)
+    with db_connection.cursor() as cursor:
+        cursor.execute(
+            IDS_QUERY,
+            (
+                "instance_id",
+                instance_id,
+            ),
+        )
+        for record in cursor:
+            logging.debug("Updating connection names for %s.", instance_id)
+            connection_id = record["connection_id"]
+            cursor.execute(
+                UPDATE_CONNECTION_NAME_QUERY,
+                (connection_name, connection_id),
+            )
+
+    # Commit all pending transactions to the database
+    db_connection.commit()
+
+
 def remove_connection(db_connection, connection_id):
     """Remove all connections corresponding to the specified ID."""
     logging.debug("Removing connection entries for %s.", connection_id)


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Python code to update connection names as instances' internal and external IPs change.

See also:
- cisagov/guacscanner-docker#42
- cisagov/guacamole-composition#76
- cisagov/ansible-role-guacamole#88
- cisagov/guacamole-packer#124
- cisagov/cool-assessment-terraform#285

## 💭 Motivation and context ##

Resolves #268.

## 🧪 Testing ##

All automated tests pass.  I also deployed a new [cisagov/guacamole-packer](https://github.com/cisagov/guacamole-packer) AMI with this change as part of the testing for cisagov/guacamole-packer#124 and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
