### PR TITLE
Handle EC2 instances with no Name tag in get_connection_name

### DIFF
--- a/src/guacscanner/_version.py
+++ b/src/guacscanner/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"

--- a/src/guacscanner/guacscanner.py
+++ b/src/guacscanner/guacscanner.py
@@ -694,7 +694,13 @@ def remove_instance_connections(db_connection, instance):
 
 def get_connection_name(instance):
     """Return the unique connection name for an EC2 instance."""
-    name = [tag["Value"] for tag in instance.tags if tag["Key"] == "Name"][0]
+    # instance.tags is None when the instance has no tags at all, and the
+    # list may not contain a Name tag.  Fall back to the instance id so we
+    # still return a usable, unique connection name instead of crashing.
+    name = next(
+        (tag["Value"] for tag in (instance.tags or []) if tag["Key"] == "Name"),
+        instance.id,
+    )
     private_ip = instance.private_ip_address
     public_ip = instance.public_ip_address
     ipv6_ip = instance.ipv6_address

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,12 +153,12 @@ def make_instance(ec2, request, subnet_id):
         )
 
         instance = response["Instances"][0]
-        return {
-            "id": instance["InstanceId"],
-            "os": os,
-            "private_ip": instance["PrivateIpAddress"],
-            "public_ip": instance.get("PublicIpAddress", None),
-        }
+        # Retrieve the instance information as a boto3 resource
+        instance_as_resource = boto3.resource("ec2").Instance(instance["InstanceId"])
+        # Inject the OS information, since it is used in some of our
+        # tests.
+        instance_as_resource.os = os
+        return instance_as_resource
 
     return _make_instance
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,29 +128,38 @@ def make_instance(ec2, request, subnet_id):
     ami = amis["Images"][0]
     ami_id = ami["ImageId"]
 
-    def _make_instance(tag_specs=Sentinel.MISSING):
+    def _make_instance(tags=Sentinel.MISSING):
         """Create an instance running the specified OS."""
-        if tag_specs is Sentinel.MISSING:
-            tag_specs = [
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Name", "Value": os.capitalize()}],
-                }
-            ]
-
-        response = ec2.run_instances(
-            ImageId=ami_id,
-            MaxCount=1,
-            MinCount=1,
-            NetworkInterfaces=[
+        kwargs = {
+            "ImageId": ami_id,
+            "MaxCount": 1,
+            "MinCount": 1,
+            "NetworkInterfaces": [
                 {
                     "AssociatePublicIpAddress": assign_public_ip,
                     "DeviceIndex": 0,
                     "SubnetId": subnet_id,
                 }
             ],
-            TagSpecifications=tag_specs,
-        )
+        }
+
+        tag_specs = [
+            {
+                # The ResourceType is required
+                "ResourceType": "instance",
+            }
+        ]
+        if tags is Sentinel.MISSING:
+            tag_specs[0]["Tags"] = [{"Key": "Name", "Value": os.capitalize()}]
+            kwargs["TagSpecifications"] = tag_specs
+        elif tags is not None:
+            tag_specs[0]["Tags"] = tags
+            kwargs["TagSpecifications"] = tag_specs
+        else:
+            # tags equal to None means not to add any tags
+            pass
+
+        response = ec2.run_instances(**kwargs)
 
         instance = response["Instances"][0]
         # Retrieve the instance information as a boto3 resource

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,10 +166,10 @@ def make_instance(ec2, request, subnet_id):
 # This is a "factory as fixture":
 # https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
 @pytest.fixture
-def args(monkeypatch, vpc_id):
+def make_args(monkeypatch, vpc_id):
     """Return a function that can be used to set sys.argv for guacscanner."""
 
-    def _args(log_level="debug"):
+    def _make_args(log_level="debug"):
         """Set sys.argv for guacscanner."""
         monkeypatch.setattr(
             sys,
@@ -191,7 +191,7 @@ def args(monkeypatch, vpc_id):
             ],
         )
 
-    return _args
+    return _make_args
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 """
 
 # Standard Python Libraries
+from enum import Enum
 import itertools
 import math
 import os
@@ -89,14 +90,23 @@ def subnet_id(ec2, vpc_cidr, vpc_id):
     return subnet["Subnet"]["SubnetId"]
 
 
+# Sentinel pattern
+class Sentinel(Enum):
+    """Sentinel value for functions that cannot use None as a default."""
+
+    MISSING = "MISSING"
+
+
+# This is a "factory as fixture":
+# https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
 @pytest.fixture(
     # Associate a nice name with each param value
     ids=lambda x: f"{x[0]} {'with' if x[1] else 'without'} public IP",
     # Returns the Cartesian product as a list of tuples
     params=itertools.product(["Linux", "Windows"], [True, False]),
 )
-def instance(ec2, request, subnet_id):
-    """Create an instance running the specified OS."""
+def make_instance(ec2, request, subnet_id):
+    """Return a function that creates an instance running the specified OS."""
     os = request.param[0]
     if os.lower() == "linux":
         ami = "amzn-ami-hvm-2017.09.1.20171103-x86_64-gp2"
@@ -118,59 +128,39 @@ def instance(ec2, request, subnet_id):
     ami = amis["Images"][0]
     ami_id = ami["ImageId"]
 
-    response = ec2.run_instances(
-        ImageId=ami_id,
-        MaxCount=1,
-        MinCount=1,
-        NetworkInterfaces=[
-            {
-                "AssociatePublicIpAddress": assign_public_ip,
-                "DeviceIndex": 0,
-                "SubnetId": subnet_id,
-            }
-        ],
-        TagSpecifications=[
-            {
-                "ResourceType": "instance",
-                "Tags": [{"Key": "Name", "Value": os.capitalize()}],
-            }
-        ],
-    )
+    def _make_instance(tag_specs=Sentinel.MISSING):
+        """Create an instance running the specified OS."""
+        if tag_specs is Sentinel.MISSING:
+            tag_specs = [
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Name", "Value": os.capitalize()}],
+                }
+            ]
 
-    instance = response["Instances"][0]
-    return {
-        "id": instance["InstanceId"],
-        "os": os,
-        "private_ip": instance["PrivateIpAddress"],
-        "public_ip": instance.get("PublicIpAddress", None),
-    }
+        response = ec2.run_instances(
+            ImageId=ami_id,
+            MaxCount=1,
+            MinCount=1,
+            NetworkInterfaces=[
+                {
+                    "AssociatePublicIpAddress": assign_public_ip,
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                }
+            ],
+            TagSpecifications=tag_specs,
+        )
 
+        instance = response["Instances"][0]
+        return {
+            "id": instance["InstanceId"],
+            "os": os,
+            "private_ip": instance["PrivateIpAddress"],
+            "public_ip": instance.get("PublicIpAddress", None),
+        }
 
-@pytest.fixture
-def instance_id(instance):
-    """Return the instance ID."""
-    return instance["id"]
-
-
-@pytest.fixture
-def instance_private_ip(instance):
-    """Return the private IP for the instance."""
-    return instance["private_ip"]
-
-
-@pytest.fixture
-def instance_public_ip(instance):
-    """Return the public IP for the instance.
-
-    Returns None if the instance does not have a public IP.
-    """
-    return instance["public_ip"]
-
-
-@pytest.fixture
-def instance_os(instance):
-    """Return the instance OS."""
-    return instance["os"]
+    return _make_instance
 
 
 # This is a "factory as fixture":

--- a/tests/test_getconnectionname.py
+++ b/tests/test_getconnectionname.py
@@ -2,41 +2,9 @@
 
 # Third-Party Libraries
 import boto3
-import pytest
 
 # cisagov Libraries
 import guacscanner
-
-
-# This is a "factory as fixture":
-# https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
-@pytest.fixture
-def make_instance(moto):
-    """Return a function that can be used to create a moto-backed instance."""
-
-    def _make_instance(tag_specs=None):
-        """Create a moto-backed EC2 resource instance for testing.
-
-        Passing tag_specs=None leaves the instance untagged, which is
-        how boto3 reports an EC2 instance that has no tags at all
-        (instance.tags is None in that case).
-        """
-        ec2 = boto3.resource("ec2", region_name="us-east-1")
-        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
-        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/24")
-        kwargs = {
-            "ImageId": "ami-12345678",
-            "MinCount": 1,
-            "MaxCount": 1,
-            "SubnetId": subnet.id,
-        }
-        if tag_specs is not None:
-            kwargs["TagSpecifications"] = tag_specs
-        instance = ec2.create_instances(**kwargs)[0]
-        instance.reload()
-        return instance
-
-    return _make_instance
 
 
 class TestGetConnectionName:
@@ -44,13 +12,16 @@ class TestGetConnectionName:
 
     def test_untagged_instance(self, make_instance):
         """An instance with no tags should not raise (tags is None)."""
-        instance = make_instance()
+        instance = make_instance(tag_specs=None)
         assert instance.tags is None
 
-        name = guacscanner.guacscanner.get_connection_name(instance)
+        # We need to retrieve the resource as a boto3 resource for
+        # compatibility with get_connection_name().
+        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
+        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
 
         # Falls back to the instance id when no Name tag is present.
-        assert instance.id in name
+        assert instance["id"] in name
 
     def test_no_name_tag(self, make_instance):
         """An instance with tags but no Name tag should not raise."""
@@ -63,9 +34,12 @@ class TestGetConnectionName:
             ]
         )
 
-        name = guacscanner.guacscanner.get_connection_name(instance)
+        # We need to retrieve the resource as a boto3 resource for
+        # compatibility with get_connection_name().
+        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
+        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
 
-        assert instance.id in name
+        assert instance["id"] in name
 
     def test_name_tag_used_when_present(self, make_instance):
         """The Name tag value is used when it is present."""
@@ -78,6 +52,9 @@ class TestGetConnectionName:
             ]
         )
 
-        name = guacscanner.guacscanner.get_connection_name(instance)
+        # We need to retrieve the resource as a boto3 resource for
+        # compatibility with get_connection_name().
+        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
+        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
 
-        assert name.startswith(f"webserver ({instance.id})")
+        assert name.startswith(f'webserver ({instance["id"]})')

--- a/tests/test_getconnectionname.py
+++ b/tests/test_getconnectionname.py
@@ -1,8 +1,5 @@
 """Tests for guacscanner's get_connection_name helper."""
 
-# Third-Party Libraries
-import boto3
-
 # cisagov Libraries
 import guacscanner
 
@@ -15,13 +12,10 @@ class TestGetConnectionName:
         instance = make_instance(tag_specs=None)
         assert instance.tags is None
 
-        # We need to retrieve the resource as a boto3 resource for
-        # compatibility with get_connection_name().
-        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
-        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
+        name = guacscanner.guacscanner.get_connection_name(instance)
 
         # Falls back to the instance id when no Name tag is present.
-        assert instance["id"] in name
+        assert instance.id in name
 
     def test_no_name_tag(self, make_instance):
         """An instance with tags but no Name tag should not raise."""
@@ -34,12 +28,9 @@ class TestGetConnectionName:
             ]
         )
 
-        # We need to retrieve the resource as a boto3 resource for
-        # compatibility with get_connection_name().
-        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
-        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
+        name = guacscanner.guacscanner.get_connection_name(instance)
 
-        assert instance["id"] in name
+        assert instance.id in name
 
     def test_name_tag_used_when_present(self, make_instance):
         """The Name tag value is used when it is present."""
@@ -52,9 +43,6 @@ class TestGetConnectionName:
             ]
         )
 
-        # We need to retrieve the resource as a boto3 resource for
-        # compatibility with get_connection_name().
-        instance_as_resource = boto3.resource("ec2").Instance(instance["id"])
-        name = guacscanner.guacscanner.get_connection_name(instance_as_resource)
+        name = guacscanner.guacscanner.get_connection_name(instance)
 
-        assert name.startswith(f'webserver ({instance["id"]})')
+        assert name.startswith(f"webserver ({instance.id})")

--- a/tests/test_getconnectionname.py
+++ b/tests/test_getconnectionname.py
@@ -2,17 +2,19 @@
 
 # Third-Party Libraries
 import boto3
-from moto import mock_aws
+import pytest
 
 # cisagov Libraries
 import guacscanner
 
 
-class TestGetConnectionName:
-    """Tests for the get_connection_name helper."""
+# This is a "factory as fixture":
+# https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
+@pytest.fixture
+def make_instance(moto):
+    """Return a function that can be used to create a moto-backed instance."""
 
-    @staticmethod
-    def __make_instance(tag_specs=None):
+    def _make_instance(tag_specs=None):
         """Create a moto-backed EC2 resource instance for testing.
 
         Passing tag_specs=None leaves the instance untagged, which is
@@ -34,10 +36,15 @@ class TestGetConnectionName:
         instance.reload()
         return instance
 
-    @mock_aws
-    def test_untagged_instance(self):
+    return _make_instance
+
+
+class TestGetConnectionName:
+    """Tests for the get_connection_name helper."""
+
+    def test_untagged_instance(self, make_instance):
         """An instance with no tags should not raise (tags is None)."""
-        instance = TestGetConnectionName.__make_instance()
+        instance = make_instance()
         assert instance.tags is None
 
         name = guacscanner.guacscanner.get_connection_name(instance)
@@ -45,10 +52,9 @@ class TestGetConnectionName:
         # Falls back to the instance id when no Name tag is present.
         assert instance.id in name
 
-    @mock_aws
-    def test_no_name_tag(self):
+    def test_no_name_tag(self, make_instance):
         """An instance with tags but no Name tag should not raise."""
-        instance = TestGetConnectionName.__make_instance(
+        instance = make_instance(
             tag_specs=[
                 {
                     "ResourceType": "instance",
@@ -61,10 +67,9 @@ class TestGetConnectionName:
 
         assert instance.id in name
 
-    @mock_aws
-    def test_name_tag_used_when_present(self):
+    def test_name_tag_used_when_present(self, make_instance):
         """The Name tag value is used when it is present."""
-        instance = TestGetConnectionName.__make_instance(
+        instance = make_instance(
             tag_specs=[
                 {
                     "ResourceType": "instance",

--- a/tests/test_getconnectionname.py
+++ b/tests/test_getconnectionname.py
@@ -9,7 +9,7 @@ class TestGetConnectionName:
 
     def test_untagged_instance(self, make_instance):
         """An instance with no tags should not raise (tags is None)."""
-        instance = make_instance(tag_specs=None)
+        instance = make_instance(tags=None)
         assert instance.tags is None
 
         name = guacscanner.guacscanner.get_connection_name(instance)
@@ -19,14 +19,7 @@ class TestGetConnectionName:
 
     def test_no_name_tag(self, make_instance):
         """An instance with tags but no Name tag should not raise."""
-        instance = make_instance(
-            tag_specs=[
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Environment", "Value": "test"}],
-                }
-            ]
-        )
+        instance = make_instance(tags=[{"Key": "Environment", "Value": "test"}])
 
         name = guacscanner.guacscanner.get_connection_name(instance)
 
@@ -34,14 +27,7 @@ class TestGetConnectionName:
 
     def test_name_tag_used_when_present(self, make_instance):
         """The Name tag value is used when it is present."""
-        instance = make_instance(
-            tag_specs=[
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Name", "Value": "webserver"}],
-                }
-            ]
-        )
+        instance = make_instance(tags=[{"Key": "Name", "Value": "webserver"}])
 
         name = guacscanner.guacscanner.get_connection_name(instance)
 

--- a/tests/test_getconnectionname.py
+++ b/tests/test_getconnectionname.py
@@ -1,0 +1,78 @@
+"""Tests for guacscanner's get_connection_name helper."""
+
+# Third-Party Libraries
+import boto3
+from moto import mock_aws
+
+# cisagov Libraries
+import guacscanner
+
+
+class TestGetConnectionName:
+    """Tests for the get_connection_name helper."""
+
+    @staticmethod
+    def __make_instance(tag_specs=None):
+        """Create a moto-backed EC2 resource instance for testing.
+
+        Passing tag_specs=None leaves the instance untagged, which is
+        how boto3 reports an EC2 instance that has no tags at all
+        (instance.tags is None in that case).
+        """
+        ec2 = boto3.resource("ec2", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/24")
+        kwargs = {
+            "ImageId": "ami-12345678",
+            "MinCount": 1,
+            "MaxCount": 1,
+            "SubnetId": subnet.id,
+        }
+        if tag_specs is not None:
+            kwargs["TagSpecifications"] = tag_specs
+        instance = ec2.create_instances(**kwargs)[0]
+        instance.reload()
+        return instance
+
+    @mock_aws
+    def test_untagged_instance(self):
+        """An instance with no tags should not raise (tags is None)."""
+        instance = TestGetConnectionName.__make_instance()
+        assert instance.tags is None
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        # Falls back to the instance id when no Name tag is present.
+        assert instance.id in name
+
+    @mock_aws
+    def test_no_name_tag(self):
+        """An instance with tags but no Name tag should not raise."""
+        instance = TestGetConnectionName.__make_instance(
+            tag_specs=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Environment", "Value": "test"}],
+                }
+            ]
+        )
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        assert instance.id in name
+
+    @mock_aws
+    def test_name_tag_used_when_present(self):
+        """The Name tag value is used when it is present."""
+        instance = TestGetConnectionName.__make_instance(
+            tag_specs=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Name", "Value": "webserver"}],
+                }
+            ]
+        )
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        assert name.startswith(f"webserver ({instance.id})")

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -6,6 +6,8 @@ import os
 import sys
 
 # Third-Party Libraries
+import boto3
+from moto import mock_aws
 import pytest
 
 # cisagov Libraries
@@ -372,3 +374,73 @@ class TestInstanceLifecycle:
             postgres_container, postgres_db_name, postgres_username
         )
         assert "(0 rows)" in response
+
+
+class TestGetConnectionName:
+    """Tests for the get_connection_name helper."""
+
+    @staticmethod
+    def __make_instance(tag_specs=None):
+        """Create a moto-backed EC2 resource instance for testing.
+
+        Passing tag_specs=None leaves the instance untagged, which is
+        how boto3 reports an EC2 instance that has no tags at all
+        (instance.tags is None in that case).
+        """
+        ec2 = boto3.resource("ec2", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/24")
+        kwargs = {
+            "ImageId": "ami-12345678",
+            "MinCount": 1,
+            "MaxCount": 1,
+            "SubnetId": subnet.id,
+        }
+        if tag_specs is not None:
+            kwargs["TagSpecifications"] = tag_specs
+        instance = ec2.create_instances(**kwargs)[0]
+        instance.reload()
+        return instance
+
+    @mock_aws
+    def test_untagged_instance(self):
+        """An instance with no tags should not raise (tags is None)."""
+        instance = TestGetConnectionName.__make_instance()
+        assert instance.tags is None
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        # Falls back to the instance id when no Name tag is present.
+        assert instance.id in name
+
+    @mock_aws
+    def test_no_name_tag(self):
+        """An instance with tags but no Name tag should not raise."""
+        instance = TestGetConnectionName.__make_instance(
+            tag_specs=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Environment", "Value": "test"}],
+                }
+            ]
+        )
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        assert instance.id in name
+
+    @mock_aws
+    def test_name_tag_used_when_present(self):
+        """The Name tag value is used when it is present."""
+        instance = TestGetConnectionName.__make_instance(
+            tag_specs=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Name", "Value": "webserver"}],
+                }
+            ]
+        )
+
+        name = guacscanner.guacscanner.get_connection_name(instance)
+
+        assert name.startswith(f"webserver ({instance.id})")

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -72,9 +72,9 @@ class TestLogLevels:
 
     @pytest.mark.parametrize("level", LOG_LEVELS)
     @pytest.mark.usefixtures("postgres_container")
-    def test_log_levels(self, args, level, monkeypatch):
+    def test_log_levels(self, make_args, level, monkeypatch):
         """Validate commandline log-level arguments."""
-        args(level)
+        make_args(level)
         monkeypatch.setattr(logging.root, "handlers", [])
         assert (
             logging.root.hasHandlers() is False
@@ -93,9 +93,9 @@ class TestLogLevels:
         ), f"root logger level should be set to {level.upper()} or equivalent"
 
     @pytest.mark.usefixtures("postgres_container")
-    def test_no_log_level_specified(self, args, monkeypatch):
+    def test_no_log_level_specified(self, make_args, monkeypatch):
         """Verify that case where no log level is specified."""
-        args("DEBUG")
+        make_args("DEBUG")
         # Drop the --log-level argument
         monkeypatch.setattr(sys, "argv", sys.argv[:1] + sys.argv[2:])
 
@@ -155,7 +155,7 @@ class TestGuacuser:
         )
 
     def test_addition_of_guacuser(
-        self, args, postgres_container, postgres_db_name, postgres_username
+        self, make_args, postgres_container, postgres_db_name, postgres_username
     ):
         """Verify that adding the guacuser works as expected."""
         # Verify that guacuser does not yet exist
@@ -165,7 +165,7 @@ class TestGuacuser:
         assert "guacadmin" in response
         assert "guacuser" not in response
 
-        args()
+        make_args()
         # First run creates guacuser.
         guacscanner.guacscanner.main()
 
@@ -181,10 +181,10 @@ class TestGuacuser:
         assert "(2 rows)" in response
 
     def test_addition_of_guacuser_already_exists(
-        self, args, postgres_container, postgres_db_name, postgres_username
+        self, make_args, postgres_container, postgres_db_name, postgres_username
     ):
         """Verify that adding the guacuser works as expected when it already exists."""
-        args()
+        make_args()
         # First run creates guacuser.
         guacscanner.guacscanner.main()
 
@@ -195,7 +195,7 @@ class TestGuacuser:
         assert "guacadmin" in response
         assert "guacuser" in response
 
-        args()
+        make_args()
         # Second run exercises the already-exists/idempotency path.
         guacscanner.guacscanner.main()
 
@@ -250,7 +250,7 @@ class TestInstanceLifecycle:
 
     def test_instance_creation(
         self,
-        args,
+        make_args,
         make_instance,
         postgres_container,
         postgres_db_name,
@@ -259,7 +259,7 @@ class TestInstanceLifecycle:
         """Verify that adding an instance works as expected."""
         instance = make_instance()
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
@@ -274,7 +274,7 @@ class TestInstanceLifecycle:
 
     def test_instance_stop(
         self,
-        args,
+        make_args,
         ec2,
         make_instance,
         postgres_container,
@@ -284,13 +284,13 @@ class TestInstanceLifecycle:
         """Verify that stopping an instance works as expected."""
         instance = make_instance()
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
         ec2.stop_instances(InstanceIds=[instance["id"]])
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
@@ -305,7 +305,7 @@ class TestInstanceLifecycle:
 
     def test_instance_restart(
         self,
-        args,
+        make_args,
         ec2,
         make_instance,
         postgres_container,
@@ -315,19 +315,19 @@ class TestInstanceLifecycle:
         """Verify that restarting an instance works as expected."""
         instance = make_instance()
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
         ec2.stop_instances(InstanceIds=[instance["id"]])
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         # Restart the existing EC2 instance
         ec2.start_instances(InstanceIds=[instance["id"]])
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         # We can't simply use instance_public_ip here because restarting
@@ -349,7 +349,7 @@ class TestInstanceLifecycle:
 
     def test_instance_terminate(
         self,
-        args,
+        make_args,
         ec2,
         make_instance,
         postgres_container,
@@ -359,13 +359,13 @@ class TestInstanceLifecycle:
         """Verify that terminating an instance works as expected."""
         instance = make_instance()
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         # Terminate the existing EC2 instance
         ec2.terminate_instances(InstanceIds=[instance["id"]])
 
-        args()
+        make_args()
         guacscanner.guacscanner.main()
 
         response = TestInstanceLifecycle.__query_connections(

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -251,23 +251,22 @@ class TestInstanceLifecycle:
     def test_instance_creation(
         self,
         args,
-        instance_id,
-        instance_os,
-        instance_private_ip,
-        instance_public_ip,
+        make_instance,
         postgres_container,
         postgres_db_name,
         postgres_username,
     ):
         """Verify that adding an instance works as expected."""
+        instance = make_instance()
+
         args()
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
-            instance_id,
-            instance_os,
-            instance_private_ip,
-            instance_public_ip,
+            instance["id"],
+            instance["os"],
+            instance["private_ip"],
+            instance["public_ip"],
             postgres_container,
             postgres_db_name,
             postgres_username,
@@ -277,29 +276,28 @@ class TestInstanceLifecycle:
         self,
         args,
         ec2,
-        instance_id,
-        instance_os,
-        instance_private_ip,
-        instance_public_ip,
+        make_instance,
         postgres_container,
         postgres_db_name,
         postgres_username,
     ):
         """Verify that stopping an instance works as expected."""
+        instance = make_instance()
+
         args()
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
-        ec2.stop_instances(InstanceIds=[instance_id])
+        ec2.stop_instances(InstanceIds=[instance["id"]])
 
         args()
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
-            instance_id,
-            instance_os,
-            instance_private_ip,
-            instance_public_ip,
+            instance["id"],
+            instance["os"],
+            instance["private_ip"],
+            instance["public_ip"],
             postgres_container,
             postgres_db_name,
             postgres_username,
@@ -309,25 +307,25 @@ class TestInstanceLifecycle:
         self,
         args,
         ec2,
-        instance_id,
-        instance_os,
-        instance_private_ip,
+        make_instance,
         postgres_container,
         postgres_db_name,
         postgres_username,
     ):
         """Verify that restarting an instance works as expected."""
+        instance = make_instance()
+
         args()
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
-        ec2.stop_instances(InstanceIds=[instance_id])
+        ec2.stop_instances(InstanceIds=[instance["id"]])
 
         args()
         guacscanner.guacscanner.main()
 
         # Restart the existing EC2 instance
-        ec2.start_instances(InstanceIds=[instance_id])
+        ec2.start_instances(InstanceIds=[instance["id"]])
 
         args()
         guacscanner.guacscanner.main()
@@ -335,14 +333,14 @@ class TestInstanceLifecycle:
         # We can't simply use instance_public_ip here because restarting
         # the instance likely will have changed the public IP, and
         # guacscanner will have persisted this change to the database.
-        response = ec2.describe_instances(InstanceIds=[instance_id])
-        instance = response["Reservations"][0]["Instances"][0]
-        new_public_ip = instance.get("PublicIpAddress", None)
+        response = ec2.describe_instances(InstanceIds=[instance["id"]])
+        new_instance = response["Reservations"][0]["Instances"][0]
+        new_public_ip = new_instance.get("PublicIpAddress", None)
 
         TestInstanceLifecycle.__check_instance(
-            instance_id,
-            instance_os,
-            instance_private_ip,
+            instance["id"],
+            instance["os"],
+            instance["private_ip"],
             new_public_ip,
             postgres_container,
             postgres_db_name,
@@ -353,17 +351,19 @@ class TestInstanceLifecycle:
         self,
         args,
         ec2,
-        instance_id,
+        make_instance,
         postgres_container,
         postgres_db_name,
         postgres_username,
     ):
         """Verify that terminating an instance works as expected."""
+        instance = make_instance()
+
         args()
         guacscanner.guacscanner.main()
 
         # Terminate the existing EC2 instance
-        ec2.terminate_instances(InstanceIds=[instance_id])
+        ec2.terminate_instances(InstanceIds=[instance["id"]])
 
         args()
         guacscanner.guacscanner.main()

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -230,8 +230,8 @@ class TestInstanceLifecycle:
     def __check_instance(
         instance_id,
         instance_os,
-        instance_private_ip,
-        instance_public_ip,
+        instance_private_ip_address,
+        instance_public_ip_address,
         postgres_container,
         postgres_db_name,
         postgres_username,
@@ -244,9 +244,9 @@ class TestInstanceLifecycle:
         assert "(1 row)" in response
         assert instance_id in response
         assert instance_os in response
-        assert instance_private_ip in response
-        if instance_public_ip is not None:
-            assert instance_public_ip in response
+        assert instance_private_ip_address in response
+        if instance_public_ip_address is not None:
+            assert instance_public_ip_address in response
 
     def test_instance_creation(
         self,
@@ -263,10 +263,10 @@ class TestInstanceLifecycle:
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
-            instance["id"],
-            instance["os"],
-            instance["private_ip"],
-            instance["public_ip"],
+            instance.id,
+            instance.os,
+            instance.private_ip_address,
+            instance.public_ip_address,
             postgres_container,
             postgres_db_name,
             postgres_username,
@@ -288,16 +288,16 @@ class TestInstanceLifecycle:
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
-        ec2.stop_instances(InstanceIds=[instance["id"]])
+        ec2.stop_instances(InstanceIds=[instance.id])
 
         make_args()
         guacscanner.guacscanner.main()
 
         TestInstanceLifecycle.__check_instance(
-            instance["id"],
-            instance["os"],
-            instance["private_ip"],
-            instance["public_ip"],
+            instance.id,
+            instance.os,
+            instance.private_ip_address,
+            instance.public_ip_address,
             postgres_container,
             postgres_db_name,
             postgres_username,
@@ -319,29 +319,28 @@ class TestInstanceLifecycle:
         guacscanner.guacscanner.main()
 
         # Stop the existing EC2 instance
-        ec2.stop_instances(InstanceIds=[instance["id"]])
+        ec2.stop_instances(InstanceIds=[instance.id])
 
         make_args()
         guacscanner.guacscanner.main()
 
         # Restart the existing EC2 instance
-        ec2.start_instances(InstanceIds=[instance["id"]])
+        ec2.start_instances(InstanceIds=[instance.id])
 
         make_args()
         guacscanner.guacscanner.main()
 
-        # We can't simply use instance_public_ip here because restarting
-        # the instance likely will have changed the public IP, and
-        # guacscanner will have persisted this change to the database.
-        response = ec2.describe_instances(InstanceIds=[instance["id"]])
-        new_instance = response["Reservations"][0]["Instances"][0]
-        new_public_ip = new_instance.get("PublicIpAddress", None)
+        # We can't simply use instance.public_ip_address here because
+        # restarting the instance likely will have changed the public
+        # IP, and guacscanner will have persisted this change to the
+        # database.
+        instance.reload()
 
         TestInstanceLifecycle.__check_instance(
-            instance["id"],
-            instance["os"],
-            instance["private_ip"],
-            new_public_ip,
+            instance.id,
+            instance.os,
+            instance.private_ip_address,
+            instance.public_ip_address,
             postgres_container,
             postgres_db_name,
             postgres_username,
@@ -363,7 +362,7 @@ class TestInstanceLifecycle:
         guacscanner.guacscanner.main()
 
         # Terminate the existing EC2 instance
-        ec2.terminate_instances(InstanceIds=[instance["id"]])
+        ec2.terminate_instances(InstanceIds=[instance.id])
 
         make_args()
         guacscanner.guacscanner.main()

--- a/tests/test_guacscanner.py
+++ b/tests/test_guacscanner.py
@@ -6,8 +6,6 @@ import os
 import sys
 
 # Third-Party Libraries
-import boto3
-from moto import mock_aws
 import pytest
 
 # cisagov Libraries
@@ -374,73 +372,3 @@ class TestInstanceLifecycle:
             postgres_container, postgres_db_name, postgres_username
         )
         assert "(0 rows)" in response
-
-
-class TestGetConnectionName:
-    """Tests for the get_connection_name helper."""
-
-    @staticmethod
-    def __make_instance(tag_specs=None):
-        """Create a moto-backed EC2 resource instance for testing.
-
-        Passing tag_specs=None leaves the instance untagged, which is
-        how boto3 reports an EC2 instance that has no tags at all
-        (instance.tags is None in that case).
-        """
-        ec2 = boto3.resource("ec2", region_name="us-east-1")
-        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
-        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/24")
-        kwargs = {
-            "ImageId": "ami-12345678",
-            "MinCount": 1,
-            "MaxCount": 1,
-            "SubnetId": subnet.id,
-        }
-        if tag_specs is not None:
-            kwargs["TagSpecifications"] = tag_specs
-        instance = ec2.create_instances(**kwargs)[0]
-        instance.reload()
-        return instance
-
-    @mock_aws
-    def test_untagged_instance(self):
-        """An instance with no tags should not raise (tags is None)."""
-        instance = TestGetConnectionName.__make_instance()
-        assert instance.tags is None
-
-        name = guacscanner.guacscanner.get_connection_name(instance)
-
-        # Falls back to the instance id when no Name tag is present.
-        assert instance.id in name
-
-    @mock_aws
-    def test_no_name_tag(self):
-        """An instance with tags but no Name tag should not raise."""
-        instance = TestGetConnectionName.__make_instance(
-            tag_specs=[
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Environment", "Value": "test"}],
-                }
-            ]
-        )
-
-        name = guacscanner.guacscanner.get_connection_name(instance)
-
-        assert instance.id in name
-
-    @mock_aws
-    def test_name_tag_used_when_present(self):
-        """The Name tag value is used when it is present."""
-        instance = TestGetConnectionName.__make_instance(
-            tag_specs=[
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Name", "Value": "webserver"}],
-                }
-            ]
-        )
-
-        name = guacscanner.guacscanner.get_connection_name(instance)
-
-        assert name.startswith(f"webserver ({instance.id})")


### PR DESCRIPTION
I work on open-source supply-chain security and was reading through the scanner while looking at how it handles EC2 state.

## Description

`get_connection_name` builds the connection name like this:

```python
name = [tag["Value"] for tag in instance.tags if tag["Key"] == "Name"][0]
```

That indexing at `[0]` breaks on two states that show up in a normal AWS account:

- An instance with no tags at all. boto3 reports `instance.tags` as `None` in that case, so iterating it raises `TypeError: 'NoneType' object is not iterable`.
- An instance that has tags but none with `Key == "Name"`. The comprehension yields an empty list and `[0]` raises `IndexError`.

`get_connection_name` runs for every instance being added or updated (`add_instance_connection` and `update_instance_connections`), so a single untagged or Name-less instance in a VPC aborts the run for that whole VPC.

## Fix

Use `next()` over `(instance.tags or [])` and fall back to `instance.id` when there is no Name tag, so the name stays usable and unique instead of crashing.

## Testing

Added unit tests for the untagged case, the tags-but-no-Name case, and the existing Name-tag path. They use moto to build real EC2 resource instances (matching how the code consumes `instance.tags`, `instance.private_ip_address`, etc.). The two new cases fail on the current code (TypeError / IndexError at guacscanner.py:697) and pass with the fix; the Name-tag test passes both ways.

`pytest tests/test_guacscanner.py::TestGetConnectionName` -> 3 passed. black/isort/flake8 clean on the changed files.